### PR TITLE
Increase the memory limit to 30M

### DIFF
--- a/conf/php-fpm.ini
+++ b/conf/php-fpm.ini
@@ -1,3 +1,4 @@
 upload_max_filesize=30M
+memory_limit = 30M 
 post_max_size=30M
 ; max_execution_time=60


### PR DESCRIPTION
memory_limit = 30M 
with upload_max_filesize so that upload could be possible. I was getting HTTP error while uploading 2 Mb files in media. This line fixes it.