### PR TITLE
Fix ldap multisite

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -200,17 +200,19 @@ then
 	ynh_replace_string "//--MULTISITE2--define" "define" $final_path/wp-config.php
 
 	ynh_mysql_connect_as $db_name $db_pwd $db_name < ../conf/sql/multisite.sql
+	plugin_network="--network"
 else
 	ynh_mysql_connect_as $db_name $db_pwd $db_name < ../conf/sql/single.sql
+	plugin_network=""
 fi
 
 #=================================================
 # ACTIVATE WORDPRESS' PLUGINS
 #=================================================
 
-$wpcli_alias plugin activate simple-ldap-login
+$wpcli_alias plugin activate simple-ldap-login $plugin_network
 # Do not activate http-authentication, this plugin is sometimes unstable
-$wpcli_alias plugin activate companion-auto-update
+$wpcli_alias plugin activate companion-auto-update $plugin_network
 
 #=================================================
 # STORE THE CHECKSUM OF THE CONFIG FILE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -129,8 +129,10 @@ ynh_backup_if_checksum_is_different "$final_path/wp-config.php"
 if [ $multisite -eq 1 ]
 then
 	ynh_replace_string "#--MULTISITE--" "" /etc/nginx/conf.d/$domain.d/$app.conf
+	plugin_network="--network"
 else
 	multisite=0
+	plugin_network=""
 	if [ $is_public -eq 0 ]
 	then
 		ynh_replace_string "#--PRIVATE--" "" /etc/nginx/conf.d/$domain.d/$app.conf
@@ -151,7 +153,7 @@ update_plugin () {
 }
 update_plugin simple-ldap-login
 update_plugin companion-auto-update
-$wpcli_alias plugin activate companion-auto-update
+$wpcli_alias plugin activate companion-auto-update $plugin_network
 
 # Disable broken plugin http-authentication
 $wpcli_alias plugin is-installed http-authentication && $wpcli_alias plugin deactivate http-authentication


### PR DESCRIPTION
## Problem
- *Error "Simple LDAP Login could not authenticate your credentials. The security settings do not permit trying the WordPress user database as a fallback."*

## Solution
- *Simple LDAP Login plugin have to be activated on the network, not only one blog.*

## PR Status
Work finished. Package_check, basic tests and upgrade from last version OK.  
Could be reviewed and tested.

## Validation
---
*Minor decision*
- [x] **Upgrade previous version** : JimboJoe
- [x] **Code review** : JimboJoe
- [x] **Approval (LGTM)** : JimboJoe
- [ ] **Approval (LGTM)** : 
- [x] **CI succeeded** : [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/wordpress_ynh%20fix_ldap_plugin%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/wordpress_ynh%20fix_ldap_plugin%20(Official)/)  
When the PR is mark as ready to merge, you have to wait for 3 days before really merge it.