### PR TITLE
Fix issue if http-authentication is network activated

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -169,7 +169,7 @@ update_plugin wp-fail2ban
 $wpcli_alias plugin activate wp-fail2ban $plugin_network
 
 # Disable broken plugin http-authentication
-$wpcli_alias plugin is-installed http-authentication && $wpcli_alias plugin deactivate http-authentication
+$wpcli_alias plugin is-installed http-authentication && $wpcli_alias plugin deactivate http-authentication $plugin_network
 
 #=================================================
 # STORE THE CHECKSUM OF THE CONFIG FILE


### PR DESCRIPTION
## Problem
- *The upgrade process fails if http-authentication is network activated*

## Solution
- *Desactive the plugin even if it can be network activated.*

## PR Status
Work finished. Package_check, basic tests and upgrade from last version OK.  
Could be reviewed and tested.

## Validation
---
*Minor decision*
- [x] **Upgrade previous version** : JimboJoe
- [x] **Code review** : JimboJoe
- [x] **Approval (LGTM)** : JimboJoe
- [ ] **Approval (LGTM)** : 
- [x] **CI succeeded** : [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/wordpress_ynh%20fix_upgrade%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/wordpress_ynh%20fix_upgrade%20(Official)/)  
When the PR is mark as ready to merge, you have to wait for 3 days before really merge it.