### PR TITLE
Get the database prefix before modifying data

### DIFF
--- a/scripts/change_url
+++ b/scripts/change_url
@@ -109,7 +109,6 @@ fi
 
 # Get the database table prefix
 db_prefix=$(grep '^$table_prefix' "$final_path/wp-config.php" | sed "s/.*'\(.*\)'.*/\1/" )
-ynh_debug --message="db_prefix=$db_prefix"
 
 ynh_mysql_execute_as_root --sql="UPDATE ${db_prefix}options SET option_value='$new_domain$new_path' WHERE option_name='siteurl'" --database=$app
 ynh_mysql_execute_as_root --sql="UPDATE ${db_prefix}options SET option_value='$new_domain$new_path' WHERE option_name='home'" --database=$app

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -107,8 +107,11 @@ fi
 # UPDATE THE DATABASE
 #=================================================
 
-ynh_mysql_execute_as_root --sql="UPDATE wp_options SET option_value='$new_domain$new_path' WHERE option_name='siteurl'" --database=$app
-ynh_mysql_execute_as_root --sql="UPDATE wp_options SET option_value='$new_domain$new_path' WHERE option_name='home'" --database=$app
+# Get the database table prefix
+db_prefix=$(grep '^$table_prefix' "$final_path/wp-config.php" | sed "s/.*'\(.*\)'.*/\1/" )
+
+ynh_mysql_execute_as_root --sql="UPDATE ${db_prefix}options SET option_value='$new_domain$new_path' WHERE option_name='siteurl'" --database=$app
+ynh_mysql_execute_as_root --sql="UPDATE ${db_prefix}options SET option_value='$new_domain$new_path' WHERE option_name='home'" --database=$app
 
 #=================================================
 # UPDATE THE CRON

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -109,6 +109,7 @@ fi
 
 # Get the database table prefix
 db_prefix=$(grep '^$table_prefix' "$final_path/wp-config.php" | sed "s/.*'\(.*\)'.*/\1/" )
+ynh_debug --message="db_prefix=$db_prefix"
 
 ynh_mysql_execute_as_root --sql="UPDATE ${db_prefix}options SET option_value='$new_domain$new_path' WHERE option_name='siteurl'" --database=$app
 ynh_mysql_execute_as_root --sql="UPDATE ${db_prefix}options SET option_value='$new_domain$new_path' WHERE option_name='home'" --database=$app


### PR DESCRIPTION
## Problem
- *Change_url script modify the database, without checking before the table prefix used by wordpress. For migrated wordpress, it may not work.*

## Solution
- *Get the prefix before modifying the database. Fix #67*

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Kay0u
- [x] **Approval (LGTM)** : Kay0u
- [x] **Approval (LGTM)** : JimboJoe
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/wordpress_ynh%20PR68/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/wordpress_ynh%20PR68/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.