### PR TITLE
[enh] Increase memory limit to support some plugin

### DIFF
--- a/conf/php-fpm.conf
+++ b/conf/php-fpm.conf
@@ -421,6 +421,6 @@ chdir = __FINALPATH__
 ;php_admin_flag[log_errors] = on
 ;php_admin_value[memory_limit] = 32M
 
-php_admin_value[upload_max_filesize] = 30M
-php_admin_value[memory_limit] = 30M
-php_admin_value[post_max_size] = 30M
+php_admin_value[upload_max_filesize] = 50M
+php_admin_value[memory_limit] = 64M
+php_admin_value[post_max_size] = 50M


### PR DESCRIPTION
## Problem
SOme limitation are very low (see https://forum.yunohost.org/t/issue-with-wordpress-and-php-memory/7599/6 )

## Solution
Adjust it

Note: it could increase the memory necessary to run several wordpress together.

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Kayou
- [x] **Approval (LGTM)** : Kayou
- [x] **Approval (LGTM)** : frju365
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/wordpress_ynh%20PR69/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/wordpress_ynh%20PR69/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
