### PR TITLE
Change url script set a good url (with https)

### DIFF
--- a/scripts/change_url
+++ b/scripts/change_url
@@ -107,8 +107,8 @@ fi
 # UPDATE THE DATABASE
 #=================================================
 
-ynh_mysql_execute_as_root --sql="UPDATE wp_options SET option_value='$new_domain$new_path' WHERE option_name='siteurl'" --database=$app
-ynh_mysql_execute_as_root --sql="UPDATE wp_options SET option_value='$new_domain$new_path' WHERE option_name='home'" --database=$app
+ynh_mysql_execute_as_root --sql="UPDATE wp_options SET option_value='https://$new_domain$new_path' WHERE option_name='siteurl'" --database=$app
+ynh_mysql_execute_as_root --sql="UPDATE wp_options SET option_value='https://$new_domain$new_path' WHERE option_name='home'" --database=$app
 
 #=================================================
 # UPDATE THE CRON


### PR DESCRIPTION
## Problem
- Change_url script modify *siteurl* and *home* options (wp_option table) without url protocol. This causes an error 404.

## Solution
- Add *http://* before url. Fix [#70](https://github.com/YunoHost-Apps/wordpress_ynh/issues/70)

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Kay0u
- [x] **Approval (LGTM)** : Kay0u
- [x] **Approval (LGTM)** : Maniack C
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/wordpress_ynh%20PR71/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/wordpress_ynh%20PR71/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.