### PR TITLE
Replace wp fail2ban

### DIFF
--- a/check_process
+++ b/check_process
@@ -17,7 +17,6 @@
 		upgrade=1	from_commit=cbb74263e33deb0ec36f99886a2f773e36d40fd9
 		backup_restore=1
 		multi_instance=1
-		incorrect_path=1
 		port_already_use=0
 		change_url=1
 ;; Test avec multisite
@@ -37,7 +36,6 @@
 		upgrade=1
 		backup_restore=1
 		multi_instance=1
-		incorrect_path=0
 		port_already_use=0
 		change_url=0
 ;;; Levels

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -36,6 +36,23 @@ then
 fi
 
 #=================================================
+# BACKUP BEFORE UPGRADE THEN ACTIVE TRAP
+#=================================================
+ynh_script_progression --message="Backing up the app before changing its url (may take a while)..." --weight=5
+
+# Backup the current version of the app
+ynh_backup_before_upgrade
+ynh_clean_setup () {
+	# Remove the new domain config file, the remove script won't do it as it doesn't know yet its location.
+	ynh_secure_remove --file="/etc/nginx/conf.d/$new_domain.d/$app.conf"
+
+	# restore it if the upgrade fails
+	ynh_restore_upgradebackup
+}
+# Exit if an error occurs during the execution of the script
+ynh_abort_if_errors
+
+#=================================================
 # ACTIVATE MAINTENANCE MODE
 #=================================================
 ynh_script_progression --message="Activating maintenance mode..." --weight=2

--- a/scripts/install
+++ b/scripts/install
@@ -167,7 +167,7 @@ wpcli_alias="php $final_path/wp-cli.phar --allow-root --path=$final_path"
 $wpcli_alias plugin install simple-ldap-login
 $wpcli_alias plugin install http-authentication
 $wpcli_alias plugin install companion-auto-update
-$wpcli_alias plugin install wp-fail2ban
+$wpcli_alias plugin install wp-fail2ban-redux
 
 #=================================================
 # SET LANGUAGE
@@ -210,7 +210,7 @@ ynh_script_progression --message="Activating plugins..." --weight=4
 $wpcli_alias plugin activate simple-ldap-login $plugin_network
 # Do not activate http-authentication, this plugin is sometimes unstable
 $wpcli_alias plugin activate companion-auto-update $plugin_network
-$wpcli_alias plugin activate wp-fail2ban $plugin_network
+$wpcli_alias plugin activate wp-fail2ban-redux $plugin_network
 
 #=================================================
 # STORE THE CONFIG FILE CHECKSUM

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -83,6 +83,12 @@ if grep add_filter.*auto_update $final_path/wp-config.php; then
 	sed --in-place '/add_filter.*auto_update/d' $final_path/wp-config.php
 fi
 
+# Replace wp-fail2ban by wp-fail2ban-redux
+wget -nv https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar -O $final_path/wp-cli.phar
+wpcli_alias="php $final_path/wp-cli.phar --allow-root --path=$final_path"
+$wpcli_alias plugin is-installed wp-fail2ban && $wpcli_alias plugin deactivate wp-fail2ban && $wpcli_alias plugin uninstall wp-fail2ban
+$wpcli_alias plugin is-installed wp-fail2ban-redux || $wpcli_alias plugin install wp-fail2ban-redux
+
 #=================================================
 # STANDARD UPGRADE STEPS
 #=================================================
@@ -179,8 +185,8 @@ ynh_app_setting_set --app=$app --key=multisite --value=$multisite
 #=================================================
 ynh_script_progression --message="Updating plugins" --weight=11
 
-wget -nv https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar -O $final_path/wp-cli.phar
-wpcli_alias="php $final_path/wp-cli.phar --allow-root --path=$final_path"
+# wget -nv https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar -O $final_path/wp-cli.phar
+# wpcli_alias="php $final_path/wp-cli.phar --allow-root --path=$final_path"
 update_plugin () {
 	( $wpcli_alias plugin is-installed $1 && $wpcli_alias plugin update $1 ) || $wpcli_alias plugin install $1
 }
@@ -188,8 +194,8 @@ update_plugin simple-ldap-login
 $wpcli_alias plugin activate simple-ldap-login $plugin_network
 update_plugin companion-auto-update
 $wpcli_alias plugin activate companion-auto-update $plugin_network
-update_plugin wp-fail2ban
-$wpcli_alias plugin activate wp-fail2ban $plugin_network
+update_plugin wp-fail2ban-redux
+$wpcli_alias plugin activate wp-fail2ban-redux $plugin_network
 
 # Disable broken plugin http-authentication
 $wpcli_alias plugin is-installed http-authentication && $wpcli_alias plugin deactivate http-authentication $plugin_network


### PR DESCRIPTION
## Problem
- *wp-fail2ban plugin is becoming a premium plugin with a recurrent ads about going to the premium version.*
- *And the main dev of this plugin seems to not care about it.*

## Solution
- *Remove wp-fail2ban and replace it by wp-fail2ban-redux.*

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Kay0u
- [x] **Approval (LGTM)** : JimboJoe
- [x] **Approval (LGTM)** : Kay0u
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/wordpress_ynh%20PR78/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/wordpress_ynh%20PR78/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.