### PR TITLE
Always show YunoHost tile

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -32,6 +32,6 @@ location __PATH__/ {
            fastcgi_param SCRIPT_FILENAME $request_filename;
        }
 
-  #--PRIVATE--# Include SSOWAT user panel.
-  #--PRIVATE--include conf.d/yunohost_panel.conf.inc;
+  # Include SSOWAT user panel.
+  include conf.d/yunohost_panel.conf.inc;
 }


### PR DESCRIPTION
## Problem
- *TheYunoHost tile isn't shown since an upgrade of the private/public code*

## Solution
- *Always show the tile.*

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Kay0u
- [x] **Approval (LGTM)** : Kay0u
- [x] **Approval (LGTM)** : JimboJoe
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/wordpress_ynh%20PR91/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/wordpress_ynh%20PR91/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.