### PR TITLE
Action to remove maintenance mode

### DIFF
--- a/actions.toml
+++ b/actions.toml
@@ -9,3 +9,12 @@ description = "Change the public access of the app."
             type = "boolean"
             ask = "Is it a public app ?"
             default = true
+
+[disable_maintenance]
+name = "Disable the maintenance mode of Wordpress"
+command = "/bin/bash scripts/actions/disable_maintenance"
+# user = "root"  # optional
+# cwd = "/" # optional
+# accepted_return_codes = [0, 1, 2, 3]  # optional
+accepted_return_codes = [0]
+description = "Disable the maintenance mode of Wordpress if you're stuck after an upgrade"

--- a/scripts/actions/disable_maintenance
+++ b/scripts/actions/disable_maintenance
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+#=================================================
+# GENERIC STARTING
+#=================================================
+# IMPORT GENERIC HELPERS
+#=================================================
+
+source scripts/_common.sh
+source /usr/share/yunohost/helpers
+
+#=================================================
+# MANAGE SCRIPT FAILURE
+#=================================================
+
+# Exit if an error occurs during the execution of the script
+ynh_abort_if_errors
+
+#=================================================
+# RETRIEVE ARGUMENTS
+#=================================================
+
+app=${YNH_APP_INSTANCE_NAME}
+
+final_path=$(ynh_app_setting_get --app=$app --key=final_path)
+
+#=================================================
+# CHECK IF ARGUMENTS ARE CORRECT
+#=================================================
+
+#=================================================
+# CHECK IF AN ACTION HAS TO BE DONE
+#=================================================
+
+# Check the current status of the maintenance mode
+
+if [ ! -e "$final_path/.maintenance" ]
+then
+    ynh_die --message="Wordpress isn't currently under maintenance." --ret_code=0
+fi
+
+#=================================================
+# SPECIFIC ACTION
+#=================================================
+# DISABLE THE MAINTENANCE MODE
+#=================================================
+
+ynh_script_progression --message="Disabling maintenance mode..."
+
+ynh_secure_remove --file="$final_path/.maintenance"
+
+#=================================================
+# END OF SCRIPT
+#=================================================
+
+ynh_script_progression --message="Execution completed" --last


### PR DESCRIPTION
## Problem
- *Looks like the new trendy stupid idea is to have a maintenance mode likely to get stuck and from which you can't get out without going to CLI...*

## Solution
- *Add an action to get out of maintenance mode...*

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [x] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- [x] **Code review** : Kay0u
- [x] **Approval (LGTM)** :  Kay0u
*Code review and approval have to be from a member of @YunoHost-Apps/apps-group*
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/wordpress_ynh%20PR94/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/wordpress_ynh%20PR94/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.