### PR TITLE
Buster

### DIFF
--- a/check_process
+++ b/check_process
@@ -25,7 +25,7 @@
 		setup_private=1
 		setup_public=1
 		upgrade=1
-		upgrade=1	from_commit=cbb74263e33deb0ec36f99886a2f773e36d40fd9
+		upgrade=1	from_commit=00a1a6e7dd5c814f5084c11c2810f886a32bdf61
 		backup_restore=1
 		multi_instance=1
 		port_already_use=0
@@ -54,6 +54,6 @@
 Email=
 Notification=change
 ;;; Upgrade options
-	; commit=cbb74263e33deb0ec36f99886a2f773e36d40fd9
-		name=Upgrade 4.8
+	; commit=00a1a6e7dd5c814f5084c11c2810f886a32bdf61
+		name=Upgrade 5.3.2
 		manifest_arg=domain=DOMAIN&path=PATH&admin=USER&language=fr_FR&multisite=0&is_public=1&

--- a/check_process
+++ b/check_process
@@ -55,5 +55,5 @@ Email=
 Notification=change
 ;;; Upgrade options
 	; commit=00a1a6e7dd5c814f5084c11c2810f886a32bdf61
-		name=Upgrade 5.3.2
+		name=Upgrade 5.4
 		manifest_arg=domain=DOMAIN&path=PATH&admin=USER&language=fr_FR&multisite=0&is_public=1&

--- a/manifest.json
+++ b/manifest.json
@@ -10,9 +10,13 @@
 	"url": "https://wordpress.org/",
 	"license": "GPL-2.0",
 	"maintainer": {
+		"name": "None...",
+		"email": ""
+	},
+	"previous_maintainers": [{
 		"name": "Maniack Crudelis",
 		"email": "maniackc_dev@crudelis.fr"
-	},
+	}],
     "requirements": {
         "yunohost": ">= 3.6"
     },

--- a/manifest.json
+++ b/manifest.json
@@ -10,8 +10,8 @@
 	"url": "https://wordpress.org/",
 	"license": "GPL-2.0",
 	"maintainer": {
-		"name": "None...",
-		"email": ""
+		"name": "kay0u",
+		"email": "pierre@kayou.io"
 	},
 	"previous_maintainers": [{
 		"name": "Maniack Crudelis",


### PR DESCRIPTION
## Problem
- *Buster check fails on upgrade from 4.8*

## Solution
- *Change the check to 5.3.2*

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** :  
*Code review and approval have to be from a member of @YunoHost-Apps/apps-group*
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/wordpress_ynh%20PR103/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/wordpress_ynh%20PR103/)  

When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.

Own CI results for Revision: 728c59c70d1eb2b68c0fbadc21b3a9d3ec9847a8 

### Stretch
![image](https://user-images.githubusercontent.com/30271971/85890668-1c1d4080-b7ee-11ea-89e0-f68483584c54.png)

###Buster
![image](https://user-images.githubusercontent.com/30271971/85890700-2c352000-b7ee-11ea-80ff-f306dac67105.png)

