### PR TITLE
Update wordpress

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
 		"en": "Create a beautiful blog or website easily",
 		"fr": "Logiciel de création de blog ou de site Web"
 	},
-	"version": "5.6~ynh1",
+	"version": "5.6~ynh2",
 	"url": "https://wordpress.org/",
 	"license": "GPL-2.0",
 	"maintainer": {

--- a/scripts/install
+++ b/scripts/install
@@ -215,6 +215,8 @@ ynh_script_progression --message="Activating plugins..." --weight=4
 $wpcli_alias plugin activate simple-ldap-login $plugin_network
 # Do not activate http-authentication, this plugin is sometimes unstable
 $wpcli_alias plugin activate companion-auto-update $plugin_network
+# Enable the auto update of major versions
+ynh_mysql_connect_as --user=$db_name --password=$db_pwd --database=$db_name <<< "UPDATE wp_auto_updates SET onoroff='on' WHERE wp_auto_updates.name='major';"
 $wpcli_alias plugin activate wp-fail2ban-redux $plugin_network
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -246,6 +246,12 @@ update_plugin simple-ldap-login
 $wpcli_alias plugin activate simple-ldap-login $plugin_network
 update_plugin companion-auto-update
 $wpcli_alias plugin activate companion-auto-update $plugin_network
+
+
+# Enable the auto update of major versions
+db_pwd=$(ynh_app_setting_get --app=$app --key=mysqlpwd)
+ynh_mysql_connect_as --user=$db_name --password=$db_pwd --database=$db_name <<< "UPDATE wp_auto_updates SET onoroff='on' WHERE wp_auto_updates.name='major';"
+
 update_plugin wp-fail2ban-redux
 $wpcli_alias plugin activate wp-fail2ban-redux $plugin_network
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -247,10 +247,14 @@ $wpcli_alias plugin activate simple-ldap-login $plugin_network
 update_plugin companion-auto-update
 $wpcli_alias plugin activate companion-auto-update $plugin_network
 
-
-# Enable the auto update of major versions
-db_pwd=$(ynh_app_setting_get --app=$app --key=mysqlpwd)
-ynh_mysql_connect_as --user=$db_name --password=$db_pwd --database=$db_name <<< "UPDATE wp_auto_updates SET onoroff='on' WHERE wp_auto_updates.name='major';"
+if ynh_compare_current_package_version --comparison lt --version 5.6~ynh2
+then
+	# Get the database table prefix
+	db_prefix=$(grep '^$table_prefix' "$final_path/wp-config.php" | sed "s/.*'\(.*\)'.*/\1/" )
+	# Enable the auto update of major versions
+	db_pwd=$(ynh_app_setting_get --app=$app --key=mysqlpwd)
+	ynh_mysql_connect_as --user=$db_name --password=$db_pwd --database=$db_name <<< "UPDATE ${db_prefix}auto_updates SET onoroff='on' WHERE ${db_prefix}auto_updates.name='major';"
+fi
 
 update_plugin wp-fail2ban-redux
 $wpcli_alias plugin activate wp-fail2ban-redux $plugin_network


### PR DESCRIPTION
## Problem
- *Auto update for major version is not activated by default*

## Solution
- *Activate it by default. (Should be do in in upgrade script too? A user who wants to control this major version update must disable it on each new version of this package)*

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
*Minor decision*
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** :  
*Code review and approval have to be from a member of @YunoHost-Apps/apps-group*
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/wordpress_ynh%20PR-NUM-/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/wordpress_ynh%20PR-NUM-/)  
*Please replace '-NUM-' in this link by the PR number.*  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
