### PR TITLE
remove permissions for other on wp-config file

### DIFF
--- a/scripts/actions/reset_default_app
+++ b/scripts/actions/reset_default_app
@@ -77,11 +77,14 @@ echo "# Reach everyday wp-cron.php to trig the internal WordPress cron.
 # Files have to be own by the user of wordpress. To allow upgrade from the app.
 chown -R $app: $final_path
 # Except the file config wp-config.php
-chown root: $final_path/wp-config.php
+chown root:$app $final_path/wp-config.php
 
 # Reset permissions
 find $final_path/ -type f -print0 | xargs -0 chmod 0644
 find $final_path/ -type d -print0 | xargs -0 chmod 0755
+
+# Remove permissions for others
+chmod 640 $final_path/wp-config.php
 
 #=================================================
 # UPGRADE FAIL2BAN

--- a/scripts/install
+++ b/scripts/install
@@ -241,7 +241,8 @@ echo "# Reach everyday wp-cron.php to trig the internal WordPress cron.
 # Files have to be own by the user of wordpress. To allow upgrade from the app.
 chown -R $app: $final_path
 # Except the file config wp-config.php
-chown root: $final_path/wp-config.php
+chown root:$app $final_path/wp-config.php
+chmod 640 $final_path/wp-config.php
 
 #=================================================
 # SETUP FAIL2BAN

--- a/scripts/restore
+++ b/scripts/restore
@@ -91,7 +91,8 @@ ynh_system_user_create --username=$app
 # Files have to be own by the user of wordpress. To allow upgrade from the app.
 chown -R $app: $final_path
 # Except the file config wp-config.php
-chown root: $final_path/wp-config.php
+chown root:$app $final_path/wp-config.php
+chmod 640 $final_path/wp-config.php
 
 #=================================================
 # RESTORE THE PHP-FPM CONFIGURATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -220,7 +220,7 @@ then
     ynh_store_file_checksum --file="/etc/nginx/conf.d/$domain.d/$app.conf"
 
     ynh_systemd_action --service_name=nginx --action=reload
-	
+
 	plugin_network="--network"
 else
 	multisite=0
@@ -276,7 +276,8 @@ echo "# Reach everyday wp-cron.php to trig the internal WordPress cron.
 # Files have to be own by the user of wordpress. To allow upgrade from the app.
 chown -R $app: $final_path
 # Except the file config wp-config.php
-chown root: $final_path/wp-config.php
+chown root:$app $final_path/wp-config.php
+chmod 640 $final_path/wp-config.php
 
 #=================================================
 # UPGRADE FAIL2BAN


### PR DESCRIPTION
## Problem
- wp-config is readeable by others

## Solution
- change group to wordpress user and change perms to 640
## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
*Minor decision*
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** :  
*Code review and approval have to be from a member of @YunoHost-Apps/apps-group*
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/wordpress_ynh%20PR123%20(Kay0u)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/wordpress_ynh%20PR123%20(Kay0u)/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
