### PR TITLE
Fix group ownership

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -246,8 +246,6 @@ ynh_store_file_checksum --file="$final_path/wp-config.php"
 
 chmod 400 "$final_path/wp-config.php"
 chown $app:$app "$final_path/wp-config.php"
-# We do not want www-data to get access to this file through the ACLs
-setfacl -b "$final_path/wp-config.php"
 
 #=================================================
 # CREATE A CRON TASK FOR AUTOMATIC UPDATE

--- a/scripts/install
+++ b/scripts/install
@@ -230,9 +230,11 @@ $wpcli_alias plugin activate authldap $plugin_network
 $wpcli_alias plugin activate companion-auto-update $plugin_network
 $wpcli_alias plugin activate wp-fail2ban-redux $plugin_network
 
+# Set file and directories ownership
 chmod 750 "$final_path"
 chmod -R o-rwx "$final_path"
 chown -R $app:www-data "$final_path"
+chmod g+s $final_path/wp-content/uploads
 
 #=================================================
 # STORE THE CONFIG FILE CHECKSUM
@@ -243,6 +245,8 @@ ynh_store_file_checksum --file="$final_path/wp-config.php"
 
 chmod 400 "$final_path/wp-config.php"
 chown $app:$app "$final_path/wp-config.php"
+# We do not want www-data to get access to this file through the ACLs
+setfacl -b "$final_path/wp-config.php"
 
 #=================================================
 # CREATE A CRON TASK FOR AUTOMATIC UPDATE

--- a/scripts/install
+++ b/scripts/install
@@ -231,6 +231,7 @@ $wpcli_alias plugin activate companion-auto-update $plugin_network
 $wpcli_alias plugin activate wp-fail2ban-redux $plugin_network
 
 # Set file and directories ownership
+mkdir -p $final_path/wp-content/uploads
 chmod 750 "$final_path"
 chmod -R o-rwx "$final_path"
 chown -R $app:www-data "$final_path"

--- a/scripts/restore
+++ b/scripts/restore
@@ -83,8 +83,6 @@ chmod g+s $(find $final_path/wp-content/uploads -type d)
 
 chmod 400 "$final_path/wp-config.php"
 chown $app:$app "$final_path/wp-config.php"
-# We do not want www-data to get access to this file through the ACLs
-setfacl -b "$final_path/wp-config.php"
 
 #=================================================
 # RESTORE THE PHP-FPM CONFIGURATION

--- a/scripts/restore
+++ b/scripts/restore
@@ -74,12 +74,17 @@ ynh_script_progression --message="Restoring the app main directory..."
 
 ynh_restore_file --origin_path="$final_path"
 
+# Set file and directories ownership
 chmod 750 "$final_path"
 chmod -R o-rwx "$final_path"
 chown -R $app:www-data "$final_path"
+chmod g+s $final_path/wp-content/uploads
+chmod g+s $(find $final_path/wp-content/uploads -type d)
 
 chmod 400 "$final_path/wp-config.php"
 chown $app:$app "$final_path/wp-config.php"
+# We do not want www-data to get access to this file through the ACLs
+setfacl -b "$final_path/wp-config.php"
 
 #=================================================
 # RESTORE THE PHP-FPM CONFIGURATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -295,8 +295,6 @@ ynh_store_file_checksum --file="$final_path/wp-config.php"
 
 chmod 400 "$final_path/wp-config.php"
 chown $app:$app "$final_path/wp-config.php"
-# We do not want www-data to get access to this file through the ACLs
-setfacl -b "$final_path/wp-config.php"
 
 #=================================================
 # CREATE A CRON TASK FOR AUTOMATIC UPDATE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -277,9 +277,13 @@ $wpcli_alias plugin activate wp-fail2ban-redux $plugin_network
 # Disable broken plugin http-authentication
 $wpcli_alias plugin is-installed http-authentication && $wpcli_alias plugin deactivate http-authentication $plugin_network
 
+
+# Set file and directories ownership
 chmod 750 "$final_path"
 chmod -R o-rwx "$final_path"
 chown -R $app:www-data "$final_path"
+chmod g+s $final_path/wp-content/uploads
+chmod g+s $(find $final_path/wp-content/uploads -type d)
 
 #=================================================
 # STORE THE CHECKSUM OF THE CONFIG FILE
@@ -290,6 +294,8 @@ ynh_store_file_checksum --file="$final_path/wp-config.php"
 
 chmod 400 "$final_path/wp-config.php"
 chown $app:$app "$final_path/wp-config.php"
+# We do not want www-data to get access to this file through the ACLs
+setfacl -b "$final_path/wp-config.php"
 
 #=================================================
 # CREATE A CRON TASK FOR AUTOMATIC UPDATE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -279,6 +279,7 @@ $wpcli_alias plugin is-installed http-authentication && $wpcli_alias plugin deac
 
 
 # Set file and directories ownership
+mkdir -p $final_path/wp-content/uploads
 chmod 750 "$final_path"
 chmod -R o-rwx "$final_path"
 chown -R $app:www-data "$final_path"


### PR DESCRIPTION
#155 seems to have introduced a regression in the files ownership, preventing users from uploading media.

This PR makes sure all files and directories belong to `$app:$app`, in accordance with the [PHP configuration](https://github.com/YunoHost/yunohost/blob/981fca64e234848510a2daeafec1eda07516e0ac/data/helpers.d/php#L156-L157), and set ACLs to still allow `www-data` to read most of the files (except `wp-config.php`)

Closes #156, hopefully.