### PR TITLE
Fix uploads permissions

### DIFF
--- a/conf/extra_php-fpm.conf
+++ b/conf/extra_php-fpm.conf
@@ -3,3 +3,5 @@
 php_admin_value[upload_max_filesize] = 50M
 php_admin_value[memory_limit] = 64M
 php_admin_value[post_max_size] = 50M
+
+php_admin_value[upload_tmp_dir] = __FINALPATH__/wp-content/temp/

--- a/scripts/install
+++ b/scripts/install
@@ -232,10 +232,14 @@ $wpcli_alias plugin activate wp-fail2ban-redux $plugin_network
 
 # Set file and directories ownership
 mkdir -p $final_path/wp-content/uploads
-chmod 750 "$final_path"
-chmod -R o-rwx "$final_path"
+mkdir -p $final_path/wp-content/temp
 chown -R $app:www-data "$final_path"
-chmod g+s $final_path/wp-content/uploads
+find "$final_path" -type d -exec chmod 750 {} \;
+find "$final_path" -type f -exec chmod 640 {} \;
+find "$final_path/wp-content/uploads" -type d -exec chmod 770 {} \;
+find "$final_path/wp-content/temp" -type d -exec chmod 770 {} \;
+setfacl -Rm d:g:www-data:rwX "$final_path/wp-content/uploads"
+setfacl -Rm d:g:www-data:rwX "$final_path/wp-content/temp"
 
 #=================================================
 # STORE THE CONFIG FILE CHECKSUM

--- a/scripts/restore
+++ b/scripts/restore
@@ -75,11 +75,15 @@ ynh_script_progression --message="Restoring the app main directory..."
 ynh_restore_file --origin_path="$final_path"
 
 # Set file and directories ownership
-chmod 750 "$final_path"
-chmod -R o-rwx "$final_path"
+mkdir -p $final_path/wp-content/uploads
+mkdir -p $final_path/wp-content/temp
 chown -R $app:www-data "$final_path"
-chmod g+s $final_path/wp-content/uploads
-chmod g+s $(find $final_path/wp-content/uploads -type d)
+find "$final_path" -type d -exec chmod 750 {} \;
+find "$final_path" -type f -exec chmod 640 {} \;
+find "$final_path/wp-content/uploads" -type d -exec chmod 770 {} \;
+find "$final_path/wp-content/temp" -type d -exec chmod 770 {} \;
+setfacl -Rm d:g:www-data:rwX "$final_path/wp-content/uploads"
+setfacl -Rm d:g:www-data:rwX "$final_path/wp-content/temp"
 
 chmod 400 "$final_path/wp-config.php"
 chown $app:$app "$final_path/wp-config.php"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -280,11 +280,14 @@ $wpcli_alias plugin is-installed http-authentication && $wpcli_alias plugin deac
 
 # Set file and directories ownership
 mkdir -p $final_path/wp-content/uploads
-chmod 750 "$final_path"
-chmod -R o-rwx "$final_path"
+mkdir -p $final_path/wp-content/temp
 chown -R $app:www-data "$final_path"
-chmod g+s $final_path/wp-content/uploads
-chmod g+s $(find $final_path/wp-content/uploads -type d)
+find "$final_path" -type d -exec chmod 750 {} \;
+find "$final_path" -type f -exec chmod 640 {} \;
+find "$final_path/wp-content/uploads" -type d -exec chmod 770 {} \;
+find "$final_path/wp-content/temp" -type d -exec chmod 770 {} \;
+setfacl -Rm d:g:www-data:rwX "$final_path/wp-content/uploads"
+setfacl -Rm d:g:www-data:rwX "$final_path/wp-content/temp"
 
 #=================================================
 # STORE THE CHECKSUM OF THE CONFIG FILE


### PR DESCRIPTION
## Problem

Closes #173 
Partially resolves #174 
#175 
#156 

## Solution

Root cause analysis:

The whole `$final_path` belonged to `$app:$app` up until PR #155, with permissions left open to `other` users.
This means `www-data` was still able to access the uploads directory and write into it.

After PR #155, we switched to the standard given by the example app, i.e. the permissions to `$app:www-data` for webapps.

However, PHP default config template, as used for this app for 3 years now, imposes that the PHP daemon runs as `$app:$app`, which means that uploaded files created by PHP do not belong to `www-data` and cannot be read by NGINX. Resulted the issues quoted above.

To keep the standards shown by the example app, I propose to use ACLs to fix the group to `www-data` and give it the `rwX` permission to ensure files are writable and directories accessible.

However, PHP uploads are first put in a temporary directory then moved to their destination. When moving files, PHP manages to ignore the ACL, making them useless. The workaround is to specify the temporary directory in the PHP config and have ACLs applied to it.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
