### PR TITLE
Replace authldap with wpdirauth

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -103,7 +103,7 @@ ynh_script_progression --message="Installing WordPress plugins..." --weight=20
 ynh_exec_warn_less wget --no-verbose https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar --output-document=$install_dir/wp-cli.phar
 wpcli_alias="php$phpversion $install_dir/wp-cli.phar --allow-root --path=$install_dir"
 
-$wpcli_alias plugin install authldap
+$wpcli_alias plugin install wpdirauth
 $wpcli_alias plugin install http-authentication
 $wpcli_alias plugin install companion-auto-update
 $wpcli_alias plugin install wp-fail2ban-redux
@@ -156,7 +156,7 @@ fi
 #=================================================
 ynh_script_progression --message="Activating plugins..." --weight=4
 
-$wpcli_alias plugin activate authldap $plugin_network
+$wpcli_alias plugin activate wpdirauth $plugin_network
 # Do not activate http-authentication, this plugin is sometimes unstable
 $wpcli_alias plugin activate companion-auto-update $plugin_network
 $wpcli_alias plugin activate wp-fail2ban-redux $plugin_network

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -82,8 +82,9 @@ fi
 $wpcli_alias plugin is-installed wp-fail2ban && $wpcli_alias plugin deactivate $plugin_network wp-fail2ban && $wpcli_alias plugin uninstall wp-fail2ban
 $wpcli_alias plugin is-installed wp-fail2ban-redux || $wpcli_alias plugin install wp-fail2ban-redux
 
-# Remove old ldap plugin
+# Remove old ldap plugins
 $wpcli_alias plugin is-installed simple-ldap-login && $wpcli_alias plugin deactivate $plugin_network simple-ldap-login && $wpcli_alias plugin uninstall simple-ldap-login
+$wpcli_alias plugin is-installed authldap && $wpcli_alias plugin deactivate $plugin_network authldap && $wpcli_alias plugin uninstall authldap
 
 #=================================================
 # NGINX CONFIGURATION
@@ -157,8 +158,8 @@ ynh_script_progression --message="Updating plugins" --weight=11
 update_plugin () {
 	( $wpcli_alias plugin is-installed $1 && $wpcli_alias plugin update $1 ) || $wpcli_alias plugin install $1
 }
-update_plugin authldap
-$wpcli_alias plugin activate authldap $plugin_network
+update_plugin wpdirauth
+$wpcli_alias plugin activate wpdirauth $plugin_network
 update_plugin companion-auto-update
 $wpcli_alias plugin activate companion-auto-update $plugin_network
 


### PR DESCRIPTION
## Problem

Closes #235 

## Solution

- Replace authldap with wpdirauth (arbitrary choice, untested)
- [ ] Settings injected with SQL are yet to be updated

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
