### PR TITLE
Add recommended PHP imagick and intl modules

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -74,7 +74,7 @@ ram.runtime = "50M"
     admin.show_tile = false
 
     [resources.apt]
-    packages = "mariadb-server, php8.4-mysql, php8.4-curl, php8.4-mbstring, php8.4-xml, php8.4-zip, php8.4-gd, php8.4-soap, php8.4-ssh2, php8.4-tokenizer, php8.4-ldap"
+    packages = "mariadb-server, php8.4-mysql, php8.4-curl, php8.4-mbstring, php8.4-xml, php8.4-zip, php8.4-gd, php8.4-soap, php8.4-ssh2, php8.4-tokenizer, php8.4-ldap, php8.4-imagick, php8.4-intl"
 
     [resources.database]
     type = "mysql"


### PR DESCRIPTION
## Problem

In the health report WordPress websites are showing
```
One or more recommended modules are missing
- the optional module imagick is not installed or has been deactivated
- the optional module intl is not installed or has been deactivated
```

## Solution

Manually installed those packages on my server via `apt`. Afterwards warnings were gone. Package solution: Add `php8.4-imagick` and `php8.4-intl` to manifest.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
