### PR TITLE
Update all db urls on change_url

### DIFF
--- a/scripts/change_url
+++ b/scripts/change_url
@@ -21,12 +21,28 @@ ynh_config_change_url_nginx
 # UPDATE THE DATABASE
 #=================================================
 
+ynh_script_progression "Updating database URLs to use new domain..."
+
 # Get the database table prefix
 db_prefix=$(grep '^$table_prefix' "$install_dir/wp-config.php" | sed "s/.*'\(.*\)'.*/\1/" )
+old_url="https://$old_domain$old_path"
+new_url="https://$new_domain$new_path"
 
-ynh_mysql_db_shell <<< "UPDATE ${db_prefix}options SET option_value='https://$new_domain$new_path' WHERE option_name='siteurl'"
+guid_wp_posts=$(ynh_mysql_db_shell <<< "SELECT guid FROM ${db_prefix}wp_posts WHERE guid LIKE '%$old_url%';" | tail -n1)
+ynh_mysql_db_shell <<< "UPDATE ${db_prefix}wp_posts SET guid = replace(guid, '$old_url','$new_url');"
+ynh_script_progression "Updated $guid_wp_posts entries in ${db_prefix}wp_posts table"
 
-ynh_mysql_db_shell <<< "UPDATE ${db_prefix}options SET option_value='https://$new_domain$new_path' WHERE option_name='home'"
+urls_wp_posts=$(ynh_mysql_db_shell <<< "SELECT id FROM ${db_prefix}wp_posts WHERE post_content LIKE '%$old_url%';" | tail -n1)
+ynh_mysql_db_shell <<< "UPDATE ${db_prefix}wp_posts SET post_content = replace(post_content, '$old_url', '$new_url');"
+ynh_script_progression "Updated $urls_wp_posts entries in ${db_prefix}wp_posts table"
+
+urls_wp_postmeta=$(ynh_mysql_db_shell <<< "SELECT meta_value FROM wp_postmeta WHERE meta_value LIKE '%$old_url%';" | tail -n1)
+ynh_mysql_db_shell <<< "UPDATE ${db_prefix}wp_postmeta SET meta_value = replace(meta_value,'$old_url','$new_url');"
+ynh_script_progression "Updated $urls_wp_postmeta entries in ${db_prefix}wp_postmeta table"
+
+ynh_mysql_db_shell <<< "UPDATE ${db_prefix}options SET option_value='$new_url' WHERE option_name='siteurl'"
+
+ynh_mysql_db_shell <<< "UPDATE ${db_prefix}options SET option_value='$new_url' WHERE option_name='home'"
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -28,17 +28,17 @@ db_prefix=$(grep '^$table_prefix' "$install_dir/wp-config.php" | sed "s/.*'\(.*\
 old_url="https://$old_domain$old_path"
 new_url="https://$new_domain$new_path"
 
-guid_wp_posts=$(ynh_mysql_db_shell <<< "SELECT guid FROM ${db_prefix}wp_posts WHERE guid LIKE '%$old_url%';" | tail -n1)
-ynh_mysql_db_shell <<< "UPDATE ${db_prefix}wp_posts SET guid = replace(guid, '$old_url','$new_url');"
-ynh_script_progression "Updated $guid_wp_posts entries in ${db_prefix}wp_posts table"
+guid_posts=$(ynh_mysql_db_shell <<< "SELECT guid FROM ${db_prefix}posts WHERE guid LIKE '%$old_url%';" | tail -n1)
+ynh_mysql_db_shell <<< "UPDATE ${db_prefix}posts SET guid = replace(guid, '$old_url','$new_url');"
+ynh_script_progression "Updated $guid_posts entries in ${db_prefix}posts table"
 
-urls_wp_posts=$(ynh_mysql_db_shell <<< "SELECT id FROM ${db_prefix}wp_posts WHERE post_content LIKE '%$old_url%';" | tail -n1)
-ynh_mysql_db_shell <<< "UPDATE ${db_prefix}wp_posts SET post_content = replace(post_content, '$old_url', '$new_url');"
-ynh_script_progression "Updated $urls_wp_posts entries in ${db_prefix}wp_posts table"
+urls_posts=$(ynh_mysql_db_shell <<< "SELECT id FROM ${db_prefix}posts WHERE post_content LIKE '%$old_url%';" | tail -n1)
+ynh_mysql_db_shell <<< "UPDATE ${db_prefix}posts SET post_content = replace(post_content, '$old_url', '$new_url');"
+ynh_script_progression "Updated $urls_posts entries in ${db_prefix}posts table"
 
-urls_wp_postmeta=$(ynh_mysql_db_shell <<< "SELECT meta_value FROM wp_postmeta WHERE meta_value LIKE '%$old_url%';" | tail -n1)
-ynh_mysql_db_shell <<< "UPDATE ${db_prefix}wp_postmeta SET meta_value = replace(meta_value,'$old_url','$new_url');"
-ynh_script_progression "Updated $urls_wp_postmeta entries in ${db_prefix}wp_postmeta table"
+urls_postmeta=$(ynh_mysql_db_shell <<< "SELECT meta_value FROM postmeta WHERE meta_value LIKE '%$old_url%';" | tail -n1)
+ynh_mysql_db_shell <<< "UPDATE ${db_prefix}postmeta SET meta_value = replace(meta_value,'$old_url','$new_url');"
+ynh_script_progression "Updated $urls_postmeta entries in ${db_prefix}postmeta table"
 
 ynh_mysql_db_shell <<< "UPDATE ${db_prefix}options SET option_value='$new_url' WHERE option_name='siteurl'"
 


### PR DESCRIPTION
Run queries to update all occurrences of the previous url
to the new url.

Provide feedback to the user while updating it.

## Problem

Fixes https://github.com/YunoHost-Apps/wordpress_ynh/issues/267

When using the `change_url` script on a Wordpress application not all URLs are updated. If content with links is already present, they would still reference the previous url.

## Solution

Run additional SQL queries to replace all relevant occurences of the old url to the new value.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
