### PR TITLE
`install`: Set PHP limits to Elementor requirements and adjust uploads likewise

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -16,7 +16,7 @@ location __PATH__/ {
               rewrite ^(.+)$ __PATH__/index.php?q=$1 last;
        }
 
-       client_max_body_size 50M;
+       client_max_body_size 512M;
 
        location ~ [^/]\.php(/|$) {
            fastcgi_split_path_info ^(.+?\.php)(/.*)$;

--- a/manifest.toml
+++ b/manifest.toml
@@ -24,9 +24,9 @@ multi_instance = true
 ldap = true
 sso = false
 
-disk = "50M"
+disk = "60M"
 ram.build = "50M"
-ram.runtime = "50M"
+ram.runtime = "512M"
 
 [install]
     [install.domain]

--- a/scripts/install
+++ b/scripts/install
@@ -7,10 +7,10 @@ source /usr/share/yunohost/helpers
 # INITIALIZE AND STORE SETTINGS
 #=================================================
 
-ynh_app_setting_set_default --key=php_memory_limit --value=128M
-ynh_app_setting_set_default --key=php_upload_max_filesize --value=50M
-ynh_app_setting_set_default --key=php_post_max_size --value=50M
-ynh_app_setting_set_default --key=php_max_file_uploads --value=50M
+ynh_app_setting_set_default --key=php_memory_limit --value=768M
+ynh_app_setting_set_default --key=php_upload_max_filesize --value=512M
+ynh_app_setting_set_default --key=php_post_max_size --value=512M
+ynh_app_setting_set_default --key=php_max_file_uploads --value=512M
 
 #=================================================
 # CHECK IF THE APP CAN BE INSTALLED WITH THESE ARGS


### PR DESCRIPTION
## Problem

See these and the comments in them: https://github.com/YunoHost-Apps/wordpress_ynh/issues/143, https://github.com/YunoHost-Apps/wordpress_ynh/issues/261

## Solution

Raise the limits: While plain WordPress without Elementor and Woocommerce works fine with the existing limits, those standard plugins need more memory.

Elementor dominates the WordPress page builder market, powering over 12 to 18 million active websites and commands an estimated 40-50% share among dedicated WordPress page builders.

To use Elementor, the official minimum PHP memory limit is 256 MB, with 512 MB recommended, and 768 MB for best performance:

https://elementor.com/help/requirements

These are the requirements just for the Elementor plugin alone. If are using additional plugins such as WooCommerce, the bare minium to avoid loading issues is 512 MB, and the best performace value of 768 MB should (if needed by the installed plugins) not be a problem on today's hardware.

With the PHP memory limit raised, it also makes sense to raise the PHP file upload limit similarily. Using 512 MB allows to upload small videos and also import backups of smaller sites when starting off: Just importing a very simple starter template and a few plugins already raises the compressed size of a wordpress backup quickliy beyond 150 MB and 512 MB works well nowadays.

This doesn't change existing WordPress Sites and not updates. Only newly installed apps will get these higher limits.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)