### PR TITLE
`manifest.toml`: Add German translation and default to en_US

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -4,6 +4,7 @@ id = "wordpress"
 name = "WordPress"
 description.en = "Create a beautiful blog or website easily"
 description.fr = "Logiciel de création de blog ou de site Web"
+description.de = "Hosten Sie ihren Blog oder ihre Webseite"
 
 version = "6.9.1~ynh1"
 
@@ -43,9 +44,10 @@ ram.runtime = "50M"
     [install.language]
     ask.en = "Choose the application language"
     ask.fr = "Choisissez la langue de l'application"
+    ask.de = "Wählen Sie die Sprache der Applikation"
     type = "select"
     choices = ["de_DE", "en_US", "es_ES", "fr_FR", "it_IT", "pt_PT", "pt_BR"]
-    default = "fr_FR"
+    default = "en_US"
 
     [install.admin]
     type = "user"
@@ -53,6 +55,7 @@ ram.runtime = "50M"
     [install.multisite]
     ask.en = "Enable multisite option?"
     ask.fr = "Activer l'option multisite ?"
+    ask.de = "WordPress Multisite aktivieren?"
     type = "boolean"
     default = false
 


### PR DESCRIPTION
## Problems

- Even when YunoHost is using German language, Messages in the installsation screen for the WordPress-App are in English
- Even when YunoHost is using German language, in the installsation screen for the WordPress-App the pre-selected default language for the language of the new WordPress installation is fr_FR. As YunoHost's global default language is English, it looks like a bug to see fe_FR as the pre-select application language in this case.

Of course, these behaviors would be even better:
- When the YunoHost host itself is using French, of course the pre-selected app languages should be French.
- likewise for other languages, as long as the YunoHost's language among the list of choices supported by the app's manifest.toml

I assume this minor improvement would have to be implemented in the YunoHost source itself.

## Solution

- Add German translation
- Select en_US as the default language, consistent with the English default language of YunoHost

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
