### PR TITLE
`scripts/change_url`: Replace the URL in the posts tables on URL change

### DIFF
--- a/scripts/change_url
+++ b/scripts/change_url
@@ -25,24 +25,54 @@ ynh_script_progression "Updating database URLs to use new domain..."
 
 # Get the database table prefix
 db_prefix=$(grep '^$table_prefix' "$install_dir/wp-config.php" | sed "s/.*'\(.*\)'.*/\1/" )
+# Get the old and new URLs
 old_url="https://$old_domain$old_path"
 new_url="https://$new_domain$new_path"
 
-guid_posts=$(ynh_mysql_db_shell <<< "SELECT guid FROM ${db_prefix}posts WHERE guid LIKE '%$old_url%';" | tail -n1)
-ynh_mysql_db_shell <<< "UPDATE ${db_prefix}posts SET guid = replace(guid, '$old_url','$new_url');"
-ynh_script_progression "Updated $guid_posts entries in ${db_prefix}posts table"
+# ------------------------------------------------------------------------------
+# Helper functions for replacing parts of old URLs with new URLs in the database
+# ------------------------------------------------------------------------------
 
-urls_posts=$(ynh_mysql_db_shell <<< "SELECT id FROM ${db_prefix}posts WHERE post_content LIKE '%$old_url%';" | tail -n1)
-ynh_mysql_db_shell <<< "UPDATE ${db_prefix}posts SET post_content = replace(post_content, '$old_url', '$new_url');"
-ynh_script_progression "Updated $urls_posts entries in ${db_prefix}posts table"
+# Check if a table exists in the database (e.g. postmeta may not exist)
+table_exists() {
+	ynh_mysql_db_shell <<< "SHOW TABLES LIKE '$1'" | grep -q "."
+}
 
-urls_postmeta=$(ynh_mysql_db_shell <<< "SELECT meta_value FROM postmeta WHERE meta_value LIKE '%$old_url%';" | tail -n1)
-ynh_mysql_db_shell <<< "UPDATE ${db_prefix}postmeta SET meta_value = replace(meta_value,'$old_url','$new_url');"
-ynh_script_progression "Updated $urls_postmeta entries in ${db_prefix}postmeta table"
+# Get the number of rows in a table where a column contains the old URL
+get_field_rows() {
+	ynh_mysql_db_shell <<< "SELECT COUNT(*) FROM $1 WHERE $2 LIKE '%${3}%';"
+}
 
-ynh_mysql_db_shell <<< "UPDATE ${db_prefix}options SET option_value='$new_url' WHERE option_name='siteurl'"
+# Replace old URLs with new URLs in a specific table and column
+update_urls_in_db() {
+	local table=$1
+	local column=$2
+	table_exists "$table" || return
 
-ynh_mysql_db_shell <<< "UPDATE ${db_prefix}options SET option_value='$new_url' WHERE option_name='home'"
+	local row_count=$(get_field_rows "$table" "$column" "$old_url")
+	[ "$row_count" != 0 ] || return
+
+	ynh_mysql_db_shell <<EOF
+		UPDATE $table
+		   SET $column = replace($column, '$old_url', '$new_url');
+EOF
+	ynh_script_progression "Updated $row_count $column entries in $table"
+}
+
+# ---------------------------------------------------------------------------
+# Update URLs in relevant the columns of the database that need to be updated
+# ---------------------------------------------------------------------------
+
+update_urls_in_db "${db_prefix}posts"    "guid"
+update_urls_in_db "${db_prefix}posts"    "post_content"
+update_urls_in_db "${db_prefix}postmeta" "meta_value"
+
+# Update the siteurl and home options to the new URL
+ynh_mysql_db_shell <<EOF
+	UPDATE ${db_prefix}options
+	   SET option_value = '$new_url'
+	 WHERE option_name = 'home' OR option_name = 'siteurl';
+EOF
 
 #=================================================
 # END OF SCRIPT


### PR DESCRIPTION
## Problems

- After the merge of #268, old URLs are updated to new URLs in the post tables, but the logging of it is a bit confusing: At the places where the number of changed rows would be expected, the retrieved value is actually the last entry of the old URL, which could confuse users and readers of logs.    
- At least in the tests, the `<wp_>postmeta` table does not exist, causing warnings shown in the logs and potentially the user.
- The legibility of the SQL statements added in #268 is not perfect and it uses relatively long lines, compared to the other lines in the script.
- The new code repeats the nearly the same statements 3 times
- Two update statement are setting option_value for two rows in the options table. This can be merged into one update statement for both.

## Solutions

- Fix logging the number of URL fixups the change of the URL made:
      => Use "COUNT(*)" to get the number of rows that need replacement,
         which is then shown to the user.
- Check if a table exists before attempting to update it.
- Improve legibility of SQL statements by formatting them nicely
- Improve code legibility by moving repeated calls into functions with parameters. Now it only takes 3 lines to read which columns in which tables are updated.
- Merge the two updates for the option_values of two options into one update.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)

@endorama, can you test and if you like, copy the changes into your PR?