### PR TITLE
Update nginx.conf

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -37,7 +37,7 @@ location __PATH__/ {
        }
 
        # Deny access to uploads that aren’t images, videos, music, etc.
-       location ~* ^/wp-content/uploads/.*.(html|htm|shtml|php|js|swf)$ {
+       location ~* wp-content/uploads/.*.(html|htm|shtml|php|js|swf)$ {
               deny all;
        }
 


### PR DESCRIPTION
removing an ^ that seems inappropriate

## Problem

It looks like the location wildcards were wrong for wp-content/uploads.

## Solution

Simply removing the ^

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
